### PR TITLE
feat: add license and default start for react-hooks package

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Abhushan A. Joshi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
 packages:
   - 'www'
+  - 'react-hooks'

--- a/react-hooks/index.js
+++ b/react-hooks/index.js
@@ -1,0 +1,3 @@
+export function helloWorld() {
+	console.log('Hello world! This is the start of @abhushanaj/react-hooks project');
+}

--- a/react-hooks/package.json
+++ b/react-hooks/package.json
@@ -1,0 +1,27 @@
+{
+	"name": "@abhushanaj/react-hooks",
+	"version": "0.0.1",
+	"description": "A collection of modern and server safe custom React hooks to supercharge your React application development.",
+	"main": "index.js",
+	"module": "index.js",
+	"private": false,
+	"type": "module",
+	"scripts": {},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/abhushanaj/react-hooks.abhushan.dev.git"
+	},
+	"keywords": [
+		"react",
+		"react-hook",
+		"typescript",
+		"custom",
+		"hooks"
+	],
+	"author": "Abhushan Adhikari Joshi",
+	"license": "MIT",
+	"bugs": {
+		"url": "https://github.com/abhushanaj/react-hooks.abhushan.dev/issues"
+	},
+	"homepage": "https://github.com/abhushanaj/react-hooks.abhushan.dev#readme"
+}


### PR DESCRIPTION
Setup for the main `react-hooks package` which we want to publish.