### PR TITLE
Feat/use copy to clipboard

### DIFF
--- a/.changeset/perfect-panthers-brush.md
+++ b/.changeset/perfect-panthers-brush.md
@@ -1,0 +1,5 @@
+---
+'@abhushanaj/react-hooks': minor
+---
+
+Add the useCopyToClipboard hook

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,6 +135,9 @@ importers:
       astro:
         specifier: ^4.4.0
         version: 4.4.0(typescript@5.3.3)
+      lucide-react:
+        specifier: ^0.334.0
+        version: 0.334.0(react@18.2.0)
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -5872,6 +5875,15 @@ packages:
     engines: { node: '>=10' }
     dependencies:
       yallist: 4.0.0
+
+  /lucide-react@0.334.0(react@18.2.0):
+    resolution:
+      { integrity: sha512-y0Rv/Xx6qAq4FutZ3L/efl3O9vl6NC/1p0YOg6mBfRbQ4k1JCE2rz0rnV7WC8Moxq1RY99vLATvjcqUegGJTvA== }
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0
+    dependencies:
+      react: 18.2.0
+    dev: false
 
   /lz-string@1.5.0:
     resolution:

--- a/react-hooks/src/hooks/useCopyToClipboard/index.test.ts
+++ b/react-hooks/src/hooks/useCopyToClipboard/index.test.ts
@@ -1,0 +1,65 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { useCopyToClipboard } from '.';
+
+describe('useCopyToClipboard', () => {
+	// mock the write text function
+	const mockedWriteText = vi.fn((_arg: string) => {
+		return Promise.resolve();
+	});
+
+	// use the mocked write text on navigator clipboard
+	Object.assign(navigator, {
+		clipboard: {
+			writeText: mockedWriteText
+		}
+	});
+
+	const textToCopy = 'Hello, World!';
+
+	it('should be defined', () => {
+		expect.hasAssertions();
+		expect(useCopyToClipboard).toBeDefined();
+	});
+
+	it('returns null as copied text without the copy function call', () => {
+		expect.hasAssertions();
+		const { result } = renderHook(() => useCopyToClipboard());
+		expect(result.current[0]).toBeNull();
+	});
+
+	it('returns the copied text on clipboard', async () => {
+		expect.hasAssertions();
+
+		const { result } = renderHook(() => useCopyToClipboard());
+
+		act(() => {
+			result.current[1](textToCopy);
+			expect(mockedWriteText).toBeCalledWith(textToCopy);
+		});
+
+		await waitFor(() => {
+			expect(result.current[0]).toBe(textToCopy);
+		});
+	});
+
+	it('returns null for errors', async () => {
+		expect.hasAssertions();
+
+		const { result } = renderHook(() => useCopyToClipboard());
+
+		act(() => {
+			mockedWriteText.mockImplementation((_arg: string) => Promise.reject());
+			result.current[1](textToCopy);
+			expect(mockedWriteText).toBeCalledWith(textToCopy);
+		});
+
+		await expect(mockedWriteText).rejects.toBeUndefined();
+
+		// check if the state was correctly returned
+		await waitFor(() => {
+			expect(result.current[0]).toBe(null);
+		});
+	});
+});

--- a/react-hooks/src/hooks/useCopyToClipboard/index.tsx
+++ b/react-hooks/src/hooks/useCopyToClipboard/index.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+export function useCopyToClipboard() {
+	const [copiedInfo, setCopiedInfo] = React.useState<string | null>(null);
+
+	const copyToClipboard = React.useCallback((textToCopy: string) => {
+		async function copyText() {
+			try {
+				await navigator.clipboard.writeText(textToCopy);
+				setCopiedInfo(textToCopy);
+			} catch (error) {
+				console.error('Error copying to clipboard', error);
+				setCopiedInfo(null);
+			}
+		}
+
+		void copyText();
+	}, []);
+
+	return [copiedInfo, copyToClipboard] as const;
+}

--- a/react-hooks/src/index.ts
+++ b/react-hooks/src/index.ts
@@ -5,6 +5,7 @@ export type { DocumentTitleOptions } from './hooks/useDocumentTitle';
 // ===== BOM ==========
 export { useOnline } from './hooks/useOnline';
 export { useNavigatorLanguage } from './hooks/useNavigatorLanguage';
+export { useCopyToClipboard } from './hooks/useCopyToClipboard';
 
 // ====== State ===========
 export { usePrevious } from './hooks/usePrevious';

--- a/www/package.json
+++ b/www/package.json
@@ -22,6 +22,7 @@
 		"@astrojs/starlight-tailwind": "^2.0.1",
 		"@astrojs/tailwind": "^5.1.0",
 		"astro": "^4.4.0",
+		"lucide-react": "^0.334.0",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
 		"sharp": "^0.33.2",

--- a/www/src/components/demo/useCopyToClipboard/index.tsx
+++ b/www/src/components/demo/useCopyToClipboard/index.tsx
@@ -1,0 +1,26 @@
+import { useCopyToClipboard } from '@abhushanaj/react-hooks';
+import { Check, Copy } from 'lucide-react';
+
+function UseCopyToClipboardExample() {
+	const [copiedText, copyToClipboard] = useCopyToClipboard();
+
+	const message = 'I love react!';
+
+	return (
+		<div>
+			<div className="flex items-center justify-center gap-5">
+				<h2>{message}</h2>
+				<button
+					className="flex size-7 cursor-pointer items-center justify-center rounded-md"
+					onClick={() => {
+						copyToClipboard(message);
+					}}
+				>
+					{copiedText === null ? <Copy /> : <Check />}
+				</button>
+			</div>
+		</div>
+	);
+}
+
+export default UseCopyToClipboardExample;

--- a/www/src/content/docs/hooks/bom/useCopyToClipboard.mdx
+++ b/www/src/content/docs/hooks/bom/useCopyToClipboard.mdx
@@ -1,0 +1,58 @@
+---
+title: useCopyToClipboard
+description: 'Copy text context to clipboard'
+subtitle: 'Copy text context to clipboard'
+---
+
+import Example from '@/components/demo/useCopyToClipboard';
+import { DemoWrapper } from '@/components/demo/wrapper';
+
+The `useCopyToClipboard` hook is helpful when you want to copy any text content to clipboard using the modern `navigator.clipboard.writeText` method.
+
+<DemoWrapper title="useCopyToClipboard">
+	<Example client:load />
+</DemoWrapper>
+
+## Usage
+
+Import the hook from `@abhushanaj/react-hooks` and use in required component;
+
+```tsx title="./src/App.tsx" ins={1,4}
+import { useCopyToClipboard } from '@abhushanaj/react-hooks';
+
+function App() {
+	const [copiedText, copyToClipboard] = useCopyToClipboard();
+
+	const message = 'I love react!';
+
+	return (
+		<div>
+			<h2>{message}</h2>
+			<button
+				onClick={() => {
+					copyToClipboard(message);
+				}}
+			>
+				{copiedText === null ? <Copy /> : <Check />}
+			</button>
+		</div>
+	);
+}
+
+export default App;
+```
+
+## API Reference
+
+### Return Value
+
+The hook returns a tuple with `[copiedText, copyToClipboardFn]` signature.
+
+| Parameter         | Type                | Description                             | Default |
+| ----------------- | ------------------- | --------------------------------------- | ------- |
+| copiedText        | `string\|null`      | The last value copied text to clipboard | `null`  |
+| copyToClipboardFn | `CopyToClipboardFn` | Function to copy a value to clipboard   | N/A     |
+
+### Types Value
+
+1. `CopyToClipboardFn` : `(textToCopy: string)=>void`

--- a/www/src/content/docs/hooks/bom/useCopyToClipboard.mdx
+++ b/www/src/content/docs/hooks/bom/useCopyToClipboard.mdx
@@ -53,6 +53,6 @@ The hook returns a tuple with `[copiedText, copyToClipboardFn]` signature.
 | copiedText        | `string\|null`      | The last value copied text to clipboard | `null`  |
 | copyToClipboardFn | `CopyToClipboardFn` | Function to copy a value to clipboard   | N/A     |
 
-### Types Value
+## Types Reference
 
 1. `CopyToClipboardFn` : `(textToCopy: string)=>void`


### PR DESCRIPTION
## useCopyToClipboard

Copy text content to clipboard using the `navigator.clipboard.writeText()` method.

Tasks
- [x] Add hook 
- [x] Add tests
- [x] Add docs
- [x] Add changeset