### PR TITLE
feat: useLockBodyScroll hook

### DIFF
--- a/.changeset/good-tools-carry.md
+++ b/.changeset/good-tools-carry.md
@@ -1,0 +1,5 @@
+---
+'@abhushanaj/react-hooks': minor
+---
+
+Addition of the useLockBodyScroll hook

--- a/react-hooks/src/hooks/useLockBodyScroll/index.test.tsx
+++ b/react-hooks/src/hooks/useLockBodyScroll/index.test.tsx
@@ -1,0 +1,54 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { useLockBodyScroll } from '.';
+
+function TestComponent({ isLocked = true }: { isLocked?: boolean }) {
+	useLockBodyScroll(isLocked);
+
+	return (
+		<div>
+			<button>Unlock body scroll</button>
+		</div>
+	);
+}
+
+describe('useLockBodyScroll() hook', () => {
+	it('should be defined', () => {
+		expect.hasAssertions();
+
+		expect(useLockBodyScroll).toBeDefined();
+	});
+
+	it('locks the body scroll by setting overflow:hidden by default', () => {
+		expect.hasAssertions();
+		const { unmount } = render(<TestComponent />);
+		expect(document.body.style.overflow).toBe('hidden');
+		unmount();
+	});
+
+	it('resets to original property for overflow on unmount by default', () => {
+		expect.hasAssertions();
+		const intialOverFlow = document.body.style.overflow;
+		const { unmount } = render(<TestComponent />);
+
+		unmount();
+		expect(document.body.style.overflow).toBe(intialOverFlow);
+	});
+
+	it('does not lock the scroll when isLocked is passed as false', () => {
+		expect.hasAssertions();
+		const intialOverFlow = document.body.style.overflow;
+		const { unmount } = render(<TestComponent isLocked={false} />);
+		expect(document.body.style.overflow).toBe(intialOverFlow);
+		unmount();
+	});
+
+	it('keeps the original overflow property after unmount with isLocked as false', () => {
+		expect.hasAssertions();
+		const intialOverFlow = document.body.style.overflow;
+		const { unmount } = render(<TestComponent isLocked={false} />);
+		unmount();
+		expect(document.body.style.overflow).toBe(intialOverFlow);
+	});
+});

--- a/react-hooks/src/hooks/useLockBodyScroll/index.ts
+++ b/react-hooks/src/hooks/useLockBodyScroll/index.ts
@@ -1,9 +1,11 @@
 import React from 'react';
 
+import { isSSR, noop } from '../../utils';
+
 /**
  * useLockBodyScroll hook - Locks the scrolling of the document body by setting the overflow property to hidden.
  * Useful when you are trying to render a component like dialogs/alerts, which renders the content beneath it inert.
- *
+ * @param {boolean} isLocked - Flag indicating whether to lock or unlock the body scroll. Defaults to true
  * @example
  * function Dialog() {
  *     useLockBodyScroll();
@@ -15,7 +17,7 @@ import React from 'react';
  * }
  */
 export function useLockBodyScroll(isLocked = true) {
-	React.useLayoutEffect(() => {
+	React[isSSR ? 'useEffect' : 'useLayoutEffect'](() => {
 		const documentBody = document.body;
 		const ogOverflowStyle = getComputedStyle(documentBody).overflow;
 
@@ -27,6 +29,6 @@ export function useLockBodyScroll(isLocked = true) {
 			};
 		}
 
-		return () => {};
+		return noop;
 	}, [isLocked]);
 }

--- a/react-hooks/src/hooks/useLockBodyScroll/index.ts
+++ b/react-hooks/src/hooks/useLockBodyScroll/index.ts
@@ -1,0 +1,32 @@
+import React from 'react';
+
+/**
+ * useLockBodyScroll hook - Locks the scrolling of the document body by setting the overflow property to hidden.
+ * Useful when you are trying to render a component like dialogs/alerts, which renders the content beneath it inert.
+ *
+ * @example
+ * function Dialog() {
+ *     useLockBodyScroll();
+ *     return (
+ *         <div role="dialog">
+ * 					/// You dialog content
+ *         </div>
+ *     );
+ * }
+ */
+export function useLockBodyScroll(isLocked = true) {
+	React.useLayoutEffect(() => {
+		const documentBody = document.body;
+		const ogOverflowStyle = getComputedStyle(documentBody).overflow;
+
+		if (isLocked) {
+			documentBody.style.overflow = 'hidden';
+
+			return () => {
+				documentBody.style.overflow = ogOverflowStyle;
+			};
+		}
+
+		return () => {};
+	}, [isLocked]);
+}

--- a/react-hooks/src/index.ts
+++ b/react-hooks/src/index.ts
@@ -13,3 +13,6 @@ export { useToggle } from './hooks/useToggle';
 export { useDefault } from './hooks/useDefault';
 
 // ===== Storage ===========
+
+// ======== UI ==========
+export { useLockBodyScroll } from './hooks/useLockBodyScroll';

--- a/react-hooks/src/utils/index.ts
+++ b/react-hooks/src/utils/index.ts
@@ -1,0 +1,3 @@
+export const isSSR = typeof window === 'undefined';
+
+export function noop() {}

--- a/www/astro.config.mjs
+++ b/www/astro.config.mjs
@@ -73,6 +73,10 @@ export default defineConfig({
 				{
 					label: 'State',
 					autogenerate: { directory: '/hooks/state' }
+				},
+				{
+					label: 'User Interface (UI)',
+					autogenerate: { directory: '/hooks/ui' }
 				}
 			],
 			components: {

--- a/www/src/components/demo/useLockBodyScroll/index.tsx
+++ b/www/src/components/demo/useLockBodyScroll/index.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { useLockBodyScroll } from '@abhushanaj/react-hooks';
+
+import Button from '@/components/docs/button';
+
+function UseLockBodyScrollExample() {
+	const [isLocked, setIsLocked] = React.useState(false);
+
+	useLockBodyScroll(isLocked);
+
+	return (
+		<div>
+			<p>Body Scroll is : {isLocked ? 'Locked' : 'Unlocked'}</p>
+			<Button onClick={() => setIsLocked(!isLocked)}>{!isLocked ? 'Lock Scroll' : 'Unlock Scroll'}</Button>
+		</div>
+	);
+}
+
+export default UseLockBodyScrollExample;

--- a/www/src/content/docs/hooks/ui/useLockBodyScroll.mdx
+++ b/www/src/content/docs/hooks/ui/useLockBodyScroll.mdx
@@ -1,0 +1,49 @@
+---
+title: useLockBodyScroll
+description: 'Locks the scroll of document body'
+subtitle: 'Lock the scroll of document body by setting the overflow property to hidden.'
+sidebar:
+  badge: 'New'
+---
+
+import Example from '@/components/demo/useLockBodyScroll';
+import { DemoWrapper } from '@/components/demo/wrapper';
+
+The `useLockBodyScroll` hook is helpful when you want lock the scroll behaviour of the document body by setting the overflow property to hidden.
+
+This is useful in components like `<Dialog/>` or `<Alerts/>` where you want to make the content beneath inert.
+
+<DemoWrapper title="useLockBodyScroll">
+	<Example client:load />
+</DemoWrapper>
+
+## Usage
+
+Import the hook from `@abhushanaj/react-hooks` and use in required component.
+
+```tsx title="./src/App.tsx" ins={2,6}
+import React from 'react';
+import { useLockBodyScroll } from '@abhushanaj/react-hooks';
+
+function App() {
+	const [isLocked, setIsLocked] = React.useState(false);
+	useLockBodyScroll(isLocked);
+
+	return (
+		<div>
+			<p>Body Scroll is : {isLocked ? 'Locked' : 'Unlocked'}</p>
+			<Button onClick={() => setIsLocked(!isLocked)}>{!isLocked ? 'Lock Scroll' : 'Unlock Scroll'}</Button>
+		</div>
+	);
+}
+
+export default App;
+```
+
+## API Reference
+
+### Parameters
+
+| Parameter | Type                 | Description                                        | Default |
+| --------- | -------------------- | -------------------------------------------------- | ------- |
+| isLocked  | `boolean` (optional) | Whether or not to lock the scroll on document body | `true`  |


### PR DESCRIPTION
## useLockBodyScroll

Locks the scroll on the document body by setting `overflow:hidden` and reset on unmount. 

Tasks

- [x] Add hook
- [x] Add test
- [x] Add docs
- [x] Add changeset