### PR TITLE
feat: add deprecation notice on the types for useDocumentTitle hook

### DIFF
--- a/react-hooks/src/hooks/useDocumentTitle/index.ts
+++ b/react-hooks/src/hooks/useDocumentTitle/index.ts
@@ -1,6 +1,11 @@
 import React from 'react';
 
+/**
+ * @deprecated - use the new `UseDocumentTitleOptions` type instead.
+ * This will be removed in the next major version
+ */
 export type DocumentTitleOptions = { resetOnUnmount: boolean };
+export type UseDocumentTitleOptions = { resetOnUnmount: boolean };
 
 /**
  * @param title - title to set for the document
@@ -12,7 +17,7 @@ export type DocumentTitleOptions = { resetOnUnmount: boolean };
  *   useDocumentTitle('Welcome', {resetOnUnmount : true });
  * }
  */
-export function useDocumentTitle(title: string, options?: DocumentTitleOptions) {
+export function useDocumentTitle(title: string, options?: UseDocumentTitleOptions) {
 	const { resetOnUnmount } = options || { resetOnUnmount: false };
 
 	React.useEffect(() => {

--- a/react-hooks/src/index.ts
+++ b/react-hooks/src/index.ts
@@ -1,6 +1,6 @@
 // ==== DOM ============
 export { useDocumentTitle } from './hooks/useDocumentTitle';
-export type { DocumentTitleOptions } from './hooks/useDocumentTitle';
+export type { DocumentTitleOptions, UseDocumentTitleOptions } from './hooks/useDocumentTitle';
 
 // ===== BOM ==========
 export { useOnline } from './hooks/useOnline';

--- a/www/src/content/docs/hooks/dom/useDocumentTitle.mdx
+++ b/www/src/content/docs/hooks/dom/useDocumentTitle.mdx
@@ -42,12 +42,12 @@ export default App;
 import React from 'react';
 import { useDocumentTitle } from '@abhushanaj/react-hooks';
 
-import type { DocumentTitleOptions } from '@abhushanaj/react-hooks';
+import type { UseDocumentTitleOptions } from '@abhushanaj/react-hooks';
 
 function App() {
 	const [count, setCount] = React.useState(0);
 
-	const options: DocumentTitleOptions = {
+	const options: UseDocumentTitleOptions = {
 		resetOnUnmount: true
 	};
 	useDocumentTitle(`Count: ${count}`, options);


### PR DESCRIPTION
Add a deprecation notice for using `DocumentTitleOptions` and suggest to use `UseDocumentTitleOptions` instead.

All hooks in future will follow the same convention for naming!