### PR TITLE
Feat/useIsDocumentVisible

### DIFF
--- a/.changeset/seven-students-tie.md
+++ b/.changeset/seven-students-tie.md
@@ -1,0 +1,5 @@
+---
+'@abhushanaj/react-hooks': minor
+---
+
+Add the useIsDocumentVisible hook

--- a/react-hooks/src/hooks/useIsDocumentVisible/index.test.ts
+++ b/react-hooks/src/hooks/useIsDocumentVisible/index.test.ts
@@ -1,0 +1,34 @@
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { useIsDocumentVisible } from '.';
+
+describe('useIsDocumentVisible() hook', () => {
+	const visibilitySpy = vi.spyOn(document, 'visibilityState', 'get');
+
+	it('should be defined', () => {
+		expect.hasAssertions();
+
+		expect(useIsDocumentVisible).toBeDefined();
+	});
+
+	it('returns true when the visibility state is not hidden', () => {
+		expect.hasAssertions();
+
+		visibilitySpy.mockReturnValue('visible');
+
+		const { result } = renderHook(() => useIsDocumentVisible());
+
+		expect(result.current).toBe(true);
+	});
+
+	it('returns false when the visibility state is hidden', () => {
+		expect.hasAssertions();
+
+		visibilitySpy.mockReturnValue('hidden');
+
+		const { result } = renderHook(() => useIsDocumentVisible());
+
+		expect(result.current).toBe(false);
+	});
+});

--- a/react-hooks/src/hooks/useIsDocumentVisible/index.ts
+++ b/react-hooks/src/hooks/useIsDocumentVisible/index.ts
@@ -1,5 +1,32 @@
 import React from 'react';
 
+/**
+ * useIsDocumentVisible() - Hook to subscribe and return the document's visibility state using the `document.visibilityState` property.
+ *
+ * @returns {boolean} Returns a boolean indicating whether the document is currently visible.
+ *
+ * @example
+ * import React from 'react';
+ * import { useCounter , useIsDocumentVisible } from '@abhushanaj/react-hooks';
+ *
+ * // Usage example to count the number of times the tab away action was done
+ * const ExampleComponent = () => {
+ *   const [tabAwayCount, { increment }] = useCounter(0);
+ *   const isVisible = useIsDocumentVisible();
+ *
+ *   React.useEffect(() => {
+ *     if (!isVisible) {
+ *       increment();
+ *     }
+ *   }, [isVisible]);
+ *
+ *   return (
+ *     <div>
+ *       <p>Tab Away Count: {tabAwayCount}</p>
+ *     </div>
+ *   );
+ * };
+ */
 export function useIsDocumentVisible() {
 	const getSnapshot = React.useCallback(() => {
 		return document.visibilityState === 'visible';

--- a/react-hooks/src/hooks/useIsDocumentVisible/index.ts
+++ b/react-hooks/src/hooks/useIsDocumentVisible/index.ts
@@ -1,0 +1,21 @@
+import React from 'react';
+
+export function useIsDocumentVisible() {
+	const getSnapshot = React.useCallback(() => {
+		return document.visibilityState === 'visible';
+	}, []);
+
+	const getServerSnapshot = React.useCallback(() => {
+		return true;
+	}, []);
+
+	const subscribe = React.useCallback((cb: () => void) => {
+		document.addEventListener('visibilitychange', cb);
+
+		return () => {
+			document.removeEventListener('visibilitychange', cb);
+		};
+	}, []);
+
+	return React.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}

--- a/react-hooks/src/index.ts
+++ b/react-hooks/src/index.ts
@@ -1,6 +1,7 @@
 // ==== DOM ============
 export { useDocumentTitle } from './hooks/useDocumentTitle';
 export type { DocumentTitleOptions, UseDocumentTitleOptions } from './hooks/useDocumentTitle';
+export { useIsDocumentVisible } from './hooks/useIsDocumentVisible';
 
 // ===== BOM ==========
 export { useOnline } from './hooks/useOnline';

--- a/www/src/components/demo/useIsDocumentVisible/index.tsx
+++ b/www/src/components/demo/useIsDocumentVisible/index.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { useCounter, useIsDocumentVisible } from '@abhushanaj/react-hooks';
+
+function UseIsDocumentVisibleExample() {
+	const isVisible = useIsDocumentVisible();
+
+	const [tabAwayCount, { increment }] = useCounter(0);
+
+	React.useEffect(() => {
+		if (!isVisible) {
+			increment();
+		}
+	}, [isVisible]);
+
+	return (
+		<div>
+			<p>Tab Away count is : {tabAwayCount}</p>
+			<small>Try changing the tab and check the count value</small>
+		</div>
+	);
+}
+
+export default UseIsDocumentVisibleExample;

--- a/www/src/content/docs/hooks/dom/useIsDocumentVisible.mdx
+++ b/www/src/content/docs/hooks/dom/useIsDocumentVisible.mdx
@@ -1,0 +1,58 @@
+---
+title: useIsDocumentVisible
+description: 'Tracks document visibility using the document.visibilityState property'
+subtitle: 'Tracks document visibility using the document.visibilityState property'
+sidebar:
+  badge: 'New'
+---
+
+import Example from '@/components/demo/useIsDocumentVisible';
+import { DemoWrapper } from '@/components/demo/wrapper';
+
+The `useIsDocumentVisible` hook is helpful when you want to detect a visibility change in the document.
+
+The property returns a boolean value, with `true` meaning `visible` and `false` meaning 'hidden', as per the `document.visibilityState` property.
+
+<DemoWrapper title="useIsDocumentVisible">
+	<Example client:load />
+</DemoWrapper>
+
+## Usage
+
+Import the hook from `@abhushanaj/react-hooks` and use in required component;
+
+```tsx title="./src/App.tsx" ins={1,4}
+import { useCounter, useIsDocumentVisible } from '@abhushanaj/react-hooks';
+
+function App() {
+	const isVisible = useIsDocumentVisible();
+	const [tabAwayCount, { increment }] = useCounter(0);
+
+	React.useEffect(() => {
+		if (!isVisible) {
+			increment();
+		}
+	}, [isVisible]);
+
+	return (
+		<div>
+			<p>Tab Away count is : {tabAwayCount}</p>
+			<small>Try changing the tab and check the count value</small>
+		</div>
+	);
+}
+
+export default App;
+```
+
+## Properties
+
+1. On the **server snapshot** for the component (when doing SSR), the `isVisible` property returns `true` by default.
+
+## API Reference
+
+### Return Value
+
+| Parameter | Type      | Description                                             | Default |
+| --------- | --------- | ------------------------------------------------------- | ------- |
+| isVisible | `boolean` | Boolen to mark whethere the document is visible or not. | N/A     |


### PR DESCRIPTION
## useIsDocumentVisible 

Hook to subscribe and return the document's visibility state using the `document.visibilityState` property.

Tasks 

- [x] Add hook
- [x] Add test
- [x] Add docs
- [x] Add changeset