### PR TITLE
feat: add test for strict mode enabled for the useMounted hook

### DIFF
--- a/react-hooks/src/hooks/useOnMount/index.test.tsx
+++ b/react-hooks/src/hooks/useOnMount/index.test.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { renderHook } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -36,7 +37,7 @@ describe('useOnMount() hook', () => {
 			cb: mockedCb
 		});
 
-		expect(mockedCb).toHaveBeenCalledOnce();
+		expect(mockedCb).toHaveBeenCalledTimes(1);
 	});
 
 	it('runs only once even on re-renders with different callback reference', () => {
@@ -53,7 +54,45 @@ describe('useOnMount() hook', () => {
 			cb: mockedCb2
 		});
 
-		expect(mockedCb1).toHaveBeenCalledOnce();
+		expect(mockedCb1).toHaveBeenCalledTimes(1);
+		expect(mockedCb2).not.toHaveBeenCalled();
+	});
+
+	// Strict mode settings
+	it('runs twice with strict mode enabled, even with same callback reference', () => {
+		const mockedCb = vi.fn();
+
+		expect.hasAssertions();
+		const { rerender } = renderHook(({ cb }) => useOnMount(cb), {
+			initialProps: {
+				cb: mockedCb
+			},
+			wrapper: React.StrictMode
+		});
+
+		rerender({
+			cb: mockedCb
+		});
+
+		expect(mockedCb).toHaveBeenCalledTimes(2);
+	});
+
+	it('runs twice with strict mode enabled, with different callback reference', () => {
+		const mockedCb1 = vi.fn();
+		expect.hasAssertions();
+		const { rerender } = renderHook(({ cb }) => useOnMount(cb), {
+			initialProps: {
+				cb: mockedCb1
+			},
+			wrapper: React.StrictMode
+		});
+
+		const mockedCb2 = vi.fn();
+		rerender({
+			cb: mockedCb2
+		});
+
+		expect(mockedCb1).toHaveBeenCalledTimes(2);
 		expect(mockedCb2).not.toHaveBeenCalled();
 	});
 });


### PR DESCRIPTION
Updates test on the `useOnMount` hook to consider Strict mode in React 18