### PR TITLE
Feat/use outer window size

### DIFF
--- a/.changeset/late-glasses-jam.md
+++ b/.changeset/late-glasses-jam.md
@@ -1,0 +1,5 @@
+---
+'@abhushanaj/react-hooks': minor
+---
+
+Addition of the useOuterWindowSize hook

--- a/react-hooks/src/hooks/useOuterWindowSize/index.test.ts
+++ b/react-hooks/src/hooks/useOuterWindowSize/index.test.ts
@@ -55,7 +55,7 @@ describe('useOuterWindowSize() hook', () => {
 
 		const { result, unmount } = renderHook(() => useOuterWindowSize());
 
-		// we unmount here, to the values of resize event shuld not reflect anymore
+		// we unmount here, to the values of resize event should not reflect anymore.
 		unmount();
 
 		act(() => {

--- a/react-hooks/src/hooks/useOuterWindowSize/index.test.ts
+++ b/react-hooks/src/hooks/useOuterWindowSize/index.test.ts
@@ -1,0 +1,71 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { useOuterWindowSize } from '.';
+
+describe('useOuterWindowSize() hook', () => {
+	const outerWidthSpy = vi.spyOn(window, 'outerWidth', 'get');
+	const outerHeightSpy = vi.spyOn(window, 'outerHeight', 'get');
+
+	it('should be defined', () => {
+		expect.hasAssertions();
+		expect(useOuterWindowSize).toBeDefined();
+	});
+
+	it('should return the outerWidth and outerHeight values', () => {
+		expect.hasAssertions();
+		const defaultOuterWidth = 1_000;
+		const defaultOuterHeight = 5_00;
+
+		outerWidthSpy.mockReturnValue(defaultOuterWidth);
+		outerHeightSpy.mockReturnValue(defaultOuterHeight);
+
+		const { result } = renderHook(() => useOuterWindowSize());
+
+		expect(result.current.width).toBe(defaultOuterWidth);
+		expect(result.current.height).toBe(defaultOuterHeight);
+	});
+
+	it('should update the outerWidth and outerHeight values on resize event', () => {
+		expect.hasAssertions();
+
+		const { result } = renderHook(() => useOuterWindowSize());
+
+		const updatedOuterWidth = 1_00;
+		const updatedOuterHeight = 2_00;
+
+		act(() => {
+			outerWidthSpy.mockReturnValue(updatedOuterWidth);
+			outerHeightSpy.mockReturnValue(updatedOuterHeight);
+			window.dispatchEvent(new Event('resize'));
+		});
+
+		expect(result.current.width).toBe(updatedOuterWidth);
+		expect(result.current.height).toBe(updatedOuterHeight);
+	});
+
+	it('should not give updated dimension after unmount', () => {
+		expect.hasAssertions();
+
+		const initialOuterWidth = 1_00;
+		const initialOuterHeight = 3_00;
+
+		outerWidthSpy.mockReturnValue(initialOuterWidth);
+		outerHeightSpy.mockReturnValue(initialOuterHeight);
+
+		const { result, unmount } = renderHook(() => useOuterWindowSize());
+
+		// we unmount here, to the values of resize event shuld not reflect anymore
+		unmount();
+
+		act(() => {
+			// random values updated by resize
+			outerWidthSpy.mockReturnValue(500);
+			outerHeightSpy.mockReturnValue(600);
+			window.dispatchEvent(new Event('resize'));
+		});
+
+		expect(result.current.width).toBe(initialOuterWidth);
+		expect(result.current.height).toBe(initialOuterHeight);
+	});
+});

--- a/react-hooks/src/hooks/useOuterWindowSize/index.ts
+++ b/react-hooks/src/hooks/useOuterWindowSize/index.ts
@@ -9,7 +9,7 @@ export type UseOuterWindowSizeResult = {
 
 /**
  * useOuterWindowSize() - Custm react hook to get the values of `window.outerWidth` and `window.outerHeight`. It also subscribes to the resize event to get latest values.
- * @see - https://react-hooks.abhushan.dev/hooks/ui/useouterwindowsize/
+ * @see - https://react-hooks.abhushan.dev//hooks/ui/useouterwindowsize/
  *
  */
 export function useOuterWindowSize() {

--- a/react-hooks/src/hooks/useOuterWindowSize/index.ts
+++ b/react-hooks/src/hooks/useOuterWindowSize/index.ts
@@ -8,7 +8,7 @@ export type UseOuterWindowSizeResult = {
 };
 
 /**
- * useOuterWindowSize() - Custm react hook to get the values of `window.outerWidth` and `window.outerHeight`. It also subscribes to the resize event to get latest values.
+ * useOuterWindowSize() - Custom react hook to get the values of `window.outerWidth` and `window.outerHeight`. It also subscribes to the resize event to get latest values.
  * @see - https://react-hooks.abhushan.dev//hooks/ui/useouterwindowsize/
  *
  */

--- a/react-hooks/src/hooks/useOuterWindowSize/index.ts
+++ b/react-hooks/src/hooks/useOuterWindowSize/index.ts
@@ -1,0 +1,40 @@
+import React from 'react';
+
+import { useIsomorphicLayoutEffect } from '../useIsomorphicLayoutEffect';
+
+export type UseOuterWindowSizeResult = {
+	width: number | null;
+	height: number | null;
+};
+
+/**
+ * useOuterWindowSize() - Custm react hook to get the values of `window.outerWidth` and `window.outerHeight`. It also subscribes to the resize event to get latest values.
+ * @see - https://react-hooks.abhushan.dev/hooks/ui/useouterwindowsize/
+ *
+ */
+export function useOuterWindowSize() {
+	const [dimensions, setDimensions] = React.useState<UseOuterWindowSizeResult>({
+		width: null,
+		height: null
+	});
+
+	useIsomorphicLayoutEffect(() => {
+		const updateDimenions = () => {
+			setDimensions({
+				width: window.outerWidth,
+				height: window.outerHeight
+			});
+		};
+
+		// first render values
+		updateDimenions();
+
+		window.addEventListener('resize', updateDimenions);
+
+		return () => {
+			window.removeEventListener('resize', updateDimenions);
+		};
+	}, []);
+
+	return dimensions;
+}

--- a/react-hooks/src/index.ts
+++ b/react-hooks/src/index.ts
@@ -22,6 +22,8 @@ export { useQueue } from './hooks/useQueue';
 export { useLockBodyScroll } from './hooks/useLockBodyScroll';
 export { useWindowSize } from './hooks/useWindowSize';
 export type { UseWindowSizeResult } from './hooks/useWindowSize';
+export { useOuterWindowSize } from './hooks/useOuterWindowSize';
+export type { UseOuterWindowSizeResult } from './hooks/useOuterWindowSize';
 
 // ========= Effects and Lifecycles
 export { useOnMount } from './hooks/useOnMount';

--- a/www/src/components/demo/useOuterWindowSize/index.tsx
+++ b/www/src/components/demo/useOuterWindowSize/index.tsx
@@ -1,0 +1,28 @@
+import { useOuterWindowSize } from '@abhushanaj/react-hooks';
+
+function UseOuterWindowSizeExample() {
+	const { width, height } = useOuterWindowSize();
+
+	return (
+		<div className="flex flex-col items-center justify-center gap-4">
+			<table className="border-collapse">
+				<thead>
+					<tr>
+						<th className="border p-4">Width</th>
+						<th className="border p-4">Height</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td className="border p-4">{width || 0} px</td>
+						<td className="border p-4">{height || 0} px</td>
+					</tr>
+				</tbody>
+			</table>
+
+			<small className="block">Resize your wndow screen to see changes in outer window dimenions.</small>
+		</div>
+	);
+}
+
+export default UseOuterWindowSizeExample;

--- a/www/src/content/docs/hooks/ui/useOuterWindowSize.mdx
+++ b/www/src/content/docs/hooks/ui/useOuterWindowSize.mdx
@@ -1,0 +1,55 @@
+---
+title: useOuterWindowSize
+description: Get and track the dimensions of the outer window.
+subtitle: Get and track the dimensions of the outer window.
+sidebar:
+  badge: 'New'
+---
+
+import Example from '@/components/demo/useOuterWindowSize';
+import { DemoWrapper } from '@/components/demo/wrapper';
+
+The `useOuterWindowSize` hook is helpful when you want retrieve and track the dimensions of the outer current window. It is useful for layout adjusments and conditional rendering of any component based on window size.
+
+It uses the `window.outerWidth` and `window.outerHeight` properties and also setup a subscription to the resize event to get latest values at all times.
+When using SSR, it will result in `null` values for width and height.
+
+<DemoWrapper title="useOuterWindowSize">
+	<Example client:load />
+</DemoWrapper>
+
+## Usage
+
+Import the hook from `@abhushanaj/react-hooks` and use in required component.
+
+```tsx title="./src/App.tsx" ins={1,4, 8-9}
+import { useOuterWindowSize } from '@abhushanaj/react-hooks';
+
+function App() {
+	const { width, height } = useOuterWindowSize();
+
+	return (
+		<div>
+			<p>Window Width is : {width ?? 0} px</p>
+			<p>Window Height is : {height ?? 0} px</p>
+		</div>
+	);
+}
+
+export default App;
+```
+
+## Properties
+
+1. **When Server Side Rendering (SSR) is performed**, the initial values for `width` and `height` will be `null`, and the actual dimensions will be reflected once it reaches the browser.
+
+2. The API uses the [`window.outerHeight`](https://developer.mozilla.org/en-US/docs/Web/API/Window/outerHeight) and [`window.outerWidth`](https://developer.mozilla.org/en-US/docs/Web/API/Window/outerWidth) properties to get window dimension. Learn more about them from MDN.
+
+## API Reference
+
+### Return Value
+
+| Parameter | Type           | Description                     | Default |
+| --------- | -------------- | ------------------------------- | ------- |
+| width     | `number\|null` | The width of the outer window.  | N/A     |
+| height    | `number\|null` | The height of the outer window. | N/A     |

--- a/www/src/content/docs/hooks/ui/useOuterWindowSize.mdx
+++ b/www/src/content/docs/hooks/ui/useOuterWindowSize.mdx
@@ -9,7 +9,7 @@ sidebar:
 import Example from '@/components/demo/useOuterWindowSize';
 import { DemoWrapper } from '@/components/demo/wrapper';
 
-The `useOuterWindowSize` hook is helpful when you want retrieve and track the dimensions of the outer current window. It is useful for layout adjusments and conditional rendering of any component based on window size.
+The `useOuterWindowSize` hook is helpful when you want retrieve and track the dimensions of the outer current window. It is useful for layout adjusments and conditional rendering of any component based on outer window size.
 
 It uses the `window.outerWidth` and `window.outerHeight` properties and also setup a subscription to the resize event to get latest values at all times.
 When using SSR, it will result in `null` values for width and height.


### PR DESCRIPTION
## useOuterWindowSize
Custm react hook to get the values of `window.outerWidth` and `window.outerHeight`. It also subscribes to the resize event to get latest values.

Tasks Done

- [x] Add hook
- [x] Add test
- [x] Add docs
- [x] Add changeset
