### PR TITLE
feat: addition of the useIsClient hook

### DIFF
--- a/.changeset/unlucky-sheep-cry.md
+++ b/.changeset/unlucky-sheep-cry.md
@@ -1,0 +1,5 @@
+---
+'@abhushanaj/react-hooks': minor
+---
+
+Addition of the useIsClient hook

--- a/react-hooks/src/hooks/useIsClient/index.test.tsx
+++ b/react-hooks/src/hooks/useIsClient/index.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from '@testing-library/react';
+// eslint-disable-next-line import/no-unresolved
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import type { PropsWithChildren } from 'react';
+
+import { useIsClient } from '.';
+
+describe('useIsClient() hook', () => {
+	const CLIENT_LABEL = 'Client Only';
+	const ISOMORPHIC_LABEL = 'Isomorphic';
+
+	function ClientGate(props: PropsWithChildren) {
+		const isClient = useIsClient();
+		return isClient ? props.children : null;
+	}
+
+	function TestComponent() {
+		return (
+			<div>
+				<button>{ISOMORPHIC_LABEL}</button>
+				<ClientGate>
+					<button>{CLIENT_LABEL}</button>
+				</ClientGate>
+			</div>
+		);
+	}
+
+	it('should be defined', () => {
+		expect.hasAssertions();
+		expect(useIsClient).toBeDefined();
+	});
+
+	it('should return false during SSR', () => {
+		// on SSR the button with label client should not exist in markup
+		const view = renderToStaticMarkup(<TestComponent />);
+		expect(view).not.contain(CLIENT_LABEL);
+		expect(view).contain(ISOMORPHIC_LABEL);
+	});
+
+	it('should return true on client', () => {
+		// on client both buttons must exist on screen
+		render(<TestComponent />);
+
+		const isomorphicBtn = screen.getByRole('button', {
+			name: ISOMORPHIC_LABEL
+		});
+
+		const clientBtn = screen.getByRole('button', {
+			name: CLIENT_LABEL
+		});
+
+		expect(isomorphicBtn).toBeDefined();
+		expect(clientBtn).toBeDefined();
+	});
+});

--- a/react-hooks/src/hooks/useIsClient/index.ts
+++ b/react-hooks/src/hooks/useIsClient/index.ts
@@ -4,6 +4,7 @@ import { noop } from '../../utils';
 
 /**
  * useIsClient() - Custom react hook which returns a boolean flag to indicate on whether the component was running on client side or not.
+ * @see - https://react-hooks.abhushan.dev/hooks/utilities/useisclient/
  */
 
 export function useIsClient() {

--- a/react-hooks/src/hooks/useIsClient/index.ts
+++ b/react-hooks/src/hooks/useIsClient/index.ts
@@ -1,0 +1,19 @@
+import React from 'react';
+
+import { noop } from '../../utils';
+
+/**
+ * useIsClient() - Custom react hook which returns a boolean flag to indicate on whether the component was running on client side or not.
+ */
+
+export function useIsClient() {
+	const subscribe = React.useCallback(() => {
+		return noop;
+	}, []);
+
+	const snapshot = React.useCallback(() => true, []);
+
+	const serverSnapshot = React.useCallback(() => false, []);
+
+	return React.useSyncExternalStore(subscribe, snapshot, serverSnapshot);
+}

--- a/react-hooks/src/hooks/useWasSSR/index.ts
+++ b/react-hooks/src/hooks/useWasSSR/index.ts
@@ -4,6 +4,7 @@ import { noop } from '../../utils';
 
 /**
  * useWasSSR() - Custom react hook which returns a boolean flag to indicate on whether the component was SSR.
+ * @see- https://react-hooks.abhushan.dev/hooks/utilities/usewasssr/
  */
 export function useWasSSR() {
 	const wasSSRRef = React.useRef<boolean>(false);

--- a/react-hooks/src/index.ts
+++ b/react-hooks/src/index.ts
@@ -42,3 +42,4 @@ export { useTimeout } from './hooks/useTimeout';
 // ========= Utilities ==========
 export { useDebouncedValue } from './hooks/useDebouncedValue';
 export { useWasSSR } from './hooks/useWasSSR';
+export { useIsClient } from './hooks/useIsClient';

--- a/www/src/components/demo/useIsClient/index.tsx
+++ b/www/src/components/demo/useIsClient/index.tsx
@@ -1,0 +1,40 @@
+import ClientGate from '@/components/docs/client-gate';
+
+function Box({ isClientOnly }: { isClientOnly: boolean }) {
+	return (
+		<div
+			className={`flex size-20 items-center justify-center rounded-md border-2 border-white  text-white ${isClientOnly ? 'bg-green-500' : 'bg-pink-500'}`}
+		/>
+	);
+}
+
+function UseIsClientExample() {
+	return (
+		<div>
+			{/* Markers */}
+			<div className="flex list-none items-center justify-center gap-5">
+				<div className="flex items-center gap-1">
+					<span className="block size-2 bg-pink-500" />
+					<small>Isomorphic</small>
+				</div>
+
+				<div className="flex items-center gap-1">
+					<span className="block size-2 bg-green-500" />
+					<small>Client Only</small>
+				</div>
+			</div>
+
+			{/* Box */}
+			<div className="mb-2 mt-8 flex items-center justify-center gap-4">
+				<Box isClientOnly={false} />
+				<ClientGate>
+					<Box isClientOnly />
+				</ClientGate>
+			</div>
+
+			<small>Try refreshing the page to see the client only component render after a delay.</small>
+		</div>
+	);
+}
+
+export default UseIsClientExample;

--- a/www/src/components/demo/useWasSSR/index.tsx
+++ b/www/src/components/demo/useWasSSR/index.tsx
@@ -7,13 +7,11 @@ function Box() {
 	return (
 		<div
 			className={`flex size-20 items-center justify-center rounded-md border-2 border-white  text-white ${wasSSRed ? 'bg-green-500' : 'bg-red-500'}`}
-		>
-			{wasSSRed ? 'Y' : 'N'}
-		</div>
+		/>
 	);
 }
 
-function UseLockBodyScrollExample() {
+function UseWasSSRExample() {
 	return (
 		<div>
 			{/* Markers */}
@@ -25,7 +23,7 @@ function UseLockBodyScrollExample() {
 
 				<div className="flex items-center gap-1">
 					<span className="block size-2 bg-red-500" />
-					<small>Not SSR'ed</small>
+					<small>Client Only</small>
 				</div>
 			</div>
 
@@ -40,4 +38,4 @@ function UseLockBodyScrollExample() {
 	);
 }
 
-export default UseLockBodyScrollExample;
+export default UseWasSSRExample;

--- a/www/src/components/docs/client-gate/index.tsx
+++ b/www/src/components/docs/client-gate/index.tsx
@@ -1,14 +1,9 @@
-import React from 'react';
-import { useOnMount } from '@abhushanaj/react-hooks';
+import { useIsClient } from '@abhushanaj/react-hooks';
 
 import type { PropsWithChildren } from 'react';
 
 function ClientGate(props: PropsWithChildren) {
-	const [isClient, setIsClient] = React.useState(false);
-
-	useOnMount(() => {
-		setIsClient(true);
-	});
+	const isClient = useIsClient();
 
 	return isClient ? props.children : null;
 }

--- a/www/src/content/docs/hooks/utilities/useIsClient.mdx
+++ b/www/src/content/docs/hooks/utilities/useIsClient.mdx
@@ -1,0 +1,41 @@
+---
+title: useIsClient
+description: 'Returns a boolean flag to mark if code in running on client side.'
+subtitle: 'Returns a boolean flag to mark if code in running on client side.'
+sidebar:
+  badge: 'New'
+---
+
+import Example from '@/components/demo/useIsClient';
+import { DemoWrapper } from '@/components/demo/wrapper';
+
+The `useIsClient` hook is helpful when you want to know whether the whether the component was running on client side or not.
+
+It is useful when you want to create gate-keeping components like `<ClientOnly/>` which ensures a component renders only on client, even when page is SSR'ed.
+
+<DemoWrapper title="useIsClient">
+	<Example client:load />
+</DemoWrapper>
+
+## Usage
+
+Import the hook from `@abhushanaj/react-hooks` and use in required component.
+
+```tsx title="./src/ClientOnly.tsx" ins={1,4}
+import { useIsClient } from '@abhushanaj/react-hooks';
+
+function ClientOnly(props) {
+	const isClient = useIsClient();
+	return isClient ? props.children : null;
+}
+
+export default ClientOnly;
+```
+
+## API Reference
+
+### Return Value
+
+| Parameter | Type      | Description                                       | Default |
+| --------- | --------- | ------------------------------------------------- | ------- |
+| isClient  | `boolean` | Whether or not the it is client-side environment. | N/A     |


### PR DESCRIPTION
## useIsClient

A custom utility hook to indicate whether component exist on client or not. Helpful for gate keeping components like `<ClientOnly/>` which forces a component to render only on client even in SSR.

**Tasks**
- [x] Add hook
- [x] Add test
- [x] Add docs
- [x] Add changeset

**Additional changes**
Update example for `useWasSSR`