### PR TITLE
Feat/use window listener

### DIFF
--- a/.changeset/few-hairs-greet.md
+++ b/.changeset/few-hairs-greet.md
@@ -1,0 +1,5 @@
+---
+'@abhushanaj/react-hooks': minor
+---
+
+Addition of the useWindowEventListener hook

--- a/react-hooks/src/hooks/_useEventListener/index.ts
+++ b/react-hooks/src/hooks/_useEventListener/index.ts
@@ -50,16 +50,16 @@ export function _useEventListener<T extends UseEventListenerPossibleTargets>(
 	});
 
 	React.useEffect(() => {
-		const element = (target as RefObject<Element>)?.current || (target as Element);
+		const elementOrTarget = (target as RefObject<Element>)?.current || (target as Element);
 
-		if (!element?.addEventListener) {
+		if (!elementOrTarget?.addEventListener) {
 			return;
 		}
 
-		element.addEventListener(eventName as string, callbackRef.current, options);
+		elementOrTarget.addEventListener(eventName as string, callbackRef.current, options);
 
 		return () => {
-			element.removeEventListener(eventName as string, callbackRef.current, options);
+			elementOrTarget.removeEventListener(eventName as string, callbackRef.current, options);
 		};
 	}, [eventName, target, options]);
 }

--- a/react-hooks/src/hooks/useWindowEventListener/index.test.ts
+++ b/react-hooks/src/hooks/useWindowEventListener/index.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+
+import { useWindowEventListener } from '.';
+
+/**
+ * Other test are not required since this is just a wrapper over _useEventListener which already has the necessary tests
+ */
+describe('useWindowEventListener() hook', () => {
+	it('should be defined', () => {
+		expect.hasAssertions();
+		expect(useWindowEventListener).toBeDefined();
+	});
+});

--- a/react-hooks/src/hooks/useWindowEventListener/index.ts
+++ b/react-hooks/src/hooks/useWindowEventListener/index.ts
@@ -1,0 +1,14 @@
+import type { UseEventListenerCallback, UseEventListenerEventMap, UseEventListenerOptions } from '../_useEventListener';
+
+import { _useEventListener } from '../_useEventListener';
+import { useIsClient } from '../useIsClient';
+
+export function useWindowEventListener(
+	eventName: keyof UseEventListenerEventMap<Window>,
+	callback: UseEventListenerCallback,
+	options?: UseEventListenerOptions
+) {
+	const client = useIsClient();
+
+	return _useEventListener(client ? window : (null as unknown as Window), eventName, callback, options);
+}

--- a/react-hooks/src/hooks/useWindowEventListener/index.ts
+++ b/react-hooks/src/hooks/useWindowEventListener/index.ts
@@ -3,6 +3,10 @@ import type { UseEventListenerCallback, UseEventListenerEventMap, UseEventListen
 import { _useEventListener } from '../_useEventListener';
 import { useIsClient } from '../useIsClient';
 
+/**
+ * useWindowEventListener() - Custom react hook to attch event listeners to window object.
+ * @see - https://react-hooks.abhushan.dev/hooks/window/usewindoweventlistener/
+ */
 export function useWindowEventListener(
 	eventName: keyof UseEventListenerEventMap<Window>,
 	callback: UseEventListenerCallback,

--- a/react-hooks/src/index.ts
+++ b/react-hooks/src/index.ts
@@ -8,6 +8,7 @@ export { useWindowSize } from './hooks/useWindowSize';
 export type { UseWindowSizeResult } from './hooks/useWindowSize';
 export { useOuterWindowSize } from './hooks/useOuterWindowSize';
 export type { UseOuterWindowSizeResult } from './hooks/useOuterWindowSize';
+export { useWindowEventListener } from './hooks/useWindowEventListener';
 
 // ===== BOM ==========
 export { useOnline } from './hooks/useOnline';

--- a/www/src/components/demo/useWindowEventListener/index.tsx
+++ b/www/src/components/demo/useWindowEventListener/index.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { useWindowEventListener } from '@abhushanaj/react-hooks';
+
+function UseWindowEventListenerExample() {
+	const [yScroll, setYScroll] = React.useState<number>(0);
+
+	useWindowEventListener('scroll', () => {
+		setYScroll(window.scrollY);
+	});
+
+	return (
+		<div className="flex flex-col gap-2">
+			<p>Y Scroll : {yScroll}px</p>
+			<small>Scroll on the window to get the Y scroll position</small>
+		</div>
+	);
+}
+
+export default UseWindowEventListenerExample;

--- a/www/src/content/docs/hooks/window/useWindowEventListener.mdx
+++ b/www/src/content/docs/hooks/window/useWindowEventListener.mdx
@@ -1,0 +1,57 @@
+---
+title: useWindowEventListener
+description: 'Adds an event listener to the window object.'
+subtitle: 'Adds an event listener to the window object.'
+sidebar:
+  badge: 'New'
+---
+
+import Example from '@/components/demo/useWindowEventListener';
+import { DemoWrapper } from '@/components/demo/wrapper';
+
+The `useWindowEventListener` hook is helpful when you want attach event listener to the window object and run callbacks after the event is triggered.
+
+The event listener attached will automatically be cleanuped once the component is unmounted.
+
+This hook is exactly to [useEventListenerOnRef](/hooks/ui/useeventlisteneronref/), but with [`window`](https://developer.mozilla.org/en-US/docs/Web/API/Window) object as target.
+
+<DemoWrapper title="useWindowEventListener">
+	<Example client:load />
+</DemoWrapper>
+
+## Usage
+
+Import the hook from `@abhushanaj/react-hooks` and use in required component.
+
+```tsx title="./src/App.tsx" ins={2,7-9}
+import React from 'react';
+import { useWindowEventListener } from '@abhushanaj/react-hooks';
+
+function App() {
+	const [yScroll, setYScroll] = React.useState<number>(0);
+
+	useWindowEventListener('scroll', () => {
+		setYScroll(window.scrollY);
+	});
+
+	return (
+		<div className="flex flex-col gap-2">
+			<p>Y Scroll : {yScroll}px</p>
+		</div>
+	);
+}
+
+export default App;
+```
+
+## API Reference
+
+### Parameters
+
+| Parameter | Type                                            | Description                                                            | Default     |
+| --------- | ----------------------------------------------- | ---------------------------------------------------------------------- | ----------- |
+| eventName | `string`                                        | The name of the event to listen to.                                    | N/A         |
+| callback  | `EventListenerOrEventListenerObject`            | The event handler function to be executed when the event is triggered. | N/A         |
+| options   | `AddEventListenerOptions \| boolean` (optional) | Additional options for the event listener.                             | `undefined` |
+
+**Note:** The `EventListenerOrEventListenerObject` and `AddEventListenerOptions` are standard types defined by [`lib.dom.d.ts`](https://github.com/microsoft/TypeScript/blob/main/src/lib/dom.generated.d.ts). You can refer the [MDN spec](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#parameters) for additional information.


### PR DESCRIPTION
## useWindowEventListener

Wrapper over the `_useEventListener` to create a hook to cater only for window object events.

**Tasks**
- [x] Add hook
- [x] Add test
- [x] Add docs
- [x] Add changeset