### PR TITLE
feat: useUndoState

### DIFF
--- a/.changeset/orange-apricots-return.md
+++ b/.changeset/orange-apricots-return.md
@@ -1,0 +1,5 @@
+---
+'@abhushanaj/react-hooks': minor
+---
+
+Addition of useUndoState() hook.

--- a/react-hooks/src/hooks/useUndoState/index.test.ts
+++ b/react-hooks/src/hooks/useUndoState/index.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+
+import { useUndoState } from '.';
+
+/**
+ * As this is a re-export of useStateWithHistory we don't need tests here. All tests for the parent hook should be enough.
+ */
+describe('useUndoState() hook', () => {
+	it('should be defined', () => {
+		expect(useUndoState).toBeDefined();
+	});
+});

--- a/react-hooks/src/hooks/useUndoState/index.test.ts
+++ b/react-hooks/src/hooks/useUndoState/index.test.ts
@@ -7,6 +7,7 @@ import { useUndoState } from '.';
  */
 describe('useUndoState() hook', () => {
 	it('should be defined', () => {
+		expect.hasAssertions();
 		expect(useUndoState).toBeDefined();
 	});
 });

--- a/react-hooks/src/hooks/useUndoState/index.ts
+++ b/react-hooks/src/hooks/useUndoState/index.ts
@@ -8,14 +8,15 @@ export const useUndoState = <T>(initialState: T) => {
 	/**
 	 * Simply a re-export of useStateWithHistory with only undo functionality
 	 */
-	const [state, { canUndo, undo, set }] = useStateWithHistory(initialState);
+	const [state, { canUndo, undo, set, reset }] = useStateWithHistory(initialState);
 
 	return [
 		state,
 		{
 			canUndo,
 			undo,
-			set
+			set,
+			reset
 		}
 	] as const;
 };

--- a/react-hooks/src/hooks/useUndoState/index.ts
+++ b/react-hooks/src/hooks/useUndoState/index.ts
@@ -1,0 +1,21 @@
+import { useStateWithHistory } from '../useStateWithHistory';
+
+/**
+ * useUndoState() - Custom react hook that undo functionality in state updates.
+ * @see - https://react-hooks.abhushan.dev/hooks/state/useundostate/
+ */
+export const useUndoState = <T>(initialState: T) => {
+	/**
+	 * Simply a re-export of useStateWithHistory with only undo functionality
+	 */
+	const [state, { canUndo, undo, set }] = useStateWithHistory(initialState);
+
+	return [
+		state,
+		{
+			canUndo,
+			undo,
+			set
+		}
+	] as const;
+};

--- a/react-hooks/src/index.ts
+++ b/react-hooks/src/index.ts
@@ -27,6 +27,7 @@ export { useList } from './hooks/useList';
 export { useStack } from './hooks/useStack';
 export { useCycleOn } from './hooks/useCycleOn';
 export { useStateWithHistory } from './hooks/useStateWithHistory';
+export { useUndoState } from './hooks/useUndoState';
 
 // ===== Storage ===========
 

--- a/www/src/components/demo/useUndoState/index.tsx
+++ b/www/src/components/demo/useUndoState/index.tsx
@@ -1,0 +1,43 @@
+import { useUndoState } from '@abhushanaj/react-hooks';
+
+import Button from '@/components/docs/button';
+
+function UseUndoStateExample() {
+	const [count, { canUndo, undo, set, reset }] = useUndoState(0);
+
+	return (
+		<div className="w-full">
+			<div className="my-2 flex flex-col gap-2">
+				<p className="mt-0">Count Value: {count}</p>
+			</div>
+
+			<div className="mt-6 flex flex-wrap items-center justify-center gap-8">
+				<Button
+					onClick={() => {
+						set(count + 1);
+					}}
+				>
+					+1
+				</Button>
+				<Button
+					onClick={() => {
+						set(count - 2);
+					}}
+				>
+					-2
+				</Button>
+			</div>
+
+			<div className="mt-6 flex flex-wrap items-center justify-center gap-8">
+				<Button variant="secondary" onClick={undo} disabled={!canUndo}>
+					Undo
+				</Button>
+				<Button variant="secondary" onClick={reset}>
+					Reset
+				</Button>
+			</div>
+		</div>
+	);
+}
+
+export default UseUndoStateExample;

--- a/www/src/content/docs/hooks/state/useUndoState.mdx
+++ b/www/src/content/docs/hooks/state/useUndoState.mdx
@@ -1,0 +1,92 @@
+---
+title: useUndoState
+description: 'Manage a state value with ability to undo an update.'
+subtitle: 'Manage a state value with ability to undo an update.'
+sidebar:
+  badge: 'New'
+---
+
+import Example from '@/components/demo/useUndoState';
+import { DemoWrapper } from '@/components/demo/wrapper';
+
+The `useUndoState` hook is helpful when you want to manage a state value and undo any updates on it.
+
+The hook returns the latest value of state and provides a handler to perform `undo`, `reset` and `set` actions.
+
+The hook is simply an re-export of the [useStateWithHistory](/hooks/state/usestatewithhistory/) hook, with only undo functionlity enabled.
+
+<DemoWrapper title="useUndoState">
+	<Example client:load />
+</DemoWrapper>
+
+## Usage
+
+Import the hook from `@abhushanaj/react-hooks` and use in required component.
+
+```tsx title="./src/App.tsx" ins={1,4} mark="useUndoState"
+import { useUndoState } from '@abhushanaj/react-hooks';
+
+function App() {
+	const [count, { canUndo, undo, set, reset }] = useUndoState(0);
+
+	const addByOne = () => {
+		set(count + 1);
+	};
+
+	const subtractByTwo = () => {
+		set(count - 2);
+	};
+
+	return (
+		<div>
+			<div>
+				<p>Count Value: {count}</p>
+			</div>
+
+			<div>
+				<button onClick={addByOne}>+1</button>
+				<button onClick={subtractByTwo}>-2</button>
+			</div>
+
+			<div>
+				<button onClick={undo} disabled={!canUndo}>
+					Undo
+				</button>
+				<button onClick={reset}>Reset</button>
+			</div>
+		</div>
+	);
+}
+
+export default App;
+```
+
+## API Reference
+
+### Parameters
+
+| Parameter    | Type | Description                     | Default |
+| ------------ | ---- | ------------------------------- | ------- |
+| initialValue | `T`  | The initial value of the state. | N/A     |
+
+### Return Value
+
+The hook returns a tuple with `[value, valueUpdateOptions]`.
+
+| Parameter          | Type                                          | Description                              | Default |
+| ------------------ | --------------------------------------------- | ---------------------------------------- | ------- |
+| value              | `T`                                           | The current value of state.              | N/A     |
+| valueUpdateOptions | [`ValueUpdateOptions`](#1-valueupdateoptions) | The controls for the state with history. | N/A     |
+
+## Types Reference
+
+### 1. `ValueUpdateOptions`
+
+The control options for `useStateWithHistory`.
+
+| Parameter | Type                  | Description                                                   | Default |
+| --------- | --------------------- | ------------------------------------------------------------- | ------- |
+| set       | `(newValue: T)=>void` | Function to set the new value for state.                      | N/A     |
+| undo      | `()=>void`            | Function to undo the previous state.                          | N/A     |
+| reset     | `()=>void`            | Function to reset state history and go back to initial state. | N/A     |
+| canUndo   | `boolean`             | Boolean indicating whether `undo` action is available.        | N/A     |


### PR DESCRIPTION
## useUndoState

A re-export of the useStateWithHistory hook with only the ability to set, reset and undo a state update. 

Tasks

- [x] Add hook
- [x] Add test
- [x] Add docs
- [x] Log to changeset