### PR TITLE
Feat/use subscribe to custom event

### DIFF
--- a/.changeset/eight-mice-destroy.md
+++ b/.changeset/eight-mice-destroy.md
@@ -1,0 +1,5 @@
+---
+'@abhushanaj/react-hooks': minor
+---
+
+Addition of the useDubscribeToCustomEvent hook

--- a/react-hooks/src/hooks/useSubscribeToCustomEvent/index.test.ts
+++ b/react-hooks/src/hooks/useSubscribeToCustomEvent/index.test.ts
@@ -1,0 +1,93 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { useSubscribeToCustomEvent } from '.';
+
+describe('useSubscribeToCustomEvent', () => {
+	const customEvtName = 'customEvent';
+	const customEvtPayload = {
+		data: {
+			msg: 'Hi'
+		}
+	};
+
+	it('should be defined', () => {
+		expect.hasAssertions();
+		expect(useSubscribeToCustomEvent).toBeDefined();
+	});
+
+	describe('should return the unsubscribe function', () => {
+		it('should be a function', () => {
+			expect.hasAssertions();
+			const { result } = renderHook(() => useSubscribeToCustomEvent(customEvtName, () => {}));
+			expect(result.current).toBeTypeOf('function');
+		});
+
+		it('should unsubscribe from the event after calling unsubscribe', () => {
+			expect.hasAssertions();
+
+			const mockCb = vi.fn();
+
+			const { result } = renderHook(() => useSubscribeToCustomEvent(customEvtName, mockCb));
+
+			act(() => {
+				result.current();
+			});
+
+			act(() => {
+				window.dispatchEvent(new CustomEvent(customEvtName));
+			});
+
+			expect(mockCb).not.toBeCalled();
+		});
+	});
+
+	describe('should invoke the callback for event fire', () => {
+		it('with no payload', () => {
+			expect.hasAssertions();
+
+			const mockCb = vi.fn();
+
+			renderHook(({ eventName, callback }) => useSubscribeToCustomEvent(eventName, callback), {
+				initialProps: {
+					eventName: customEvtName,
+					callback: mockCb
+				}
+			});
+
+			act(() => {
+				window.dispatchEvent(new CustomEvent(customEvtName));
+			});
+
+			expect(mockCb).toBeCalledTimes(1);
+		});
+
+		it('with some payload', () => {
+			expect.hasAssertions();
+
+			let incomingPayload: unknown = undefined;
+
+			const mockCb = vi.fn().mockImplementation((e: CustomEvent<typeof customEvtPayload>) => {
+				incomingPayload = e.detail;
+			});
+
+			renderHook(({ eventName, callback }) => useSubscribeToCustomEvent<typeof customEvtPayload>(eventName, callback), {
+				initialProps: {
+					eventName: customEvtName,
+					callback: mockCb
+				}
+			});
+
+			act(() => {
+				window.dispatchEvent(
+					new CustomEvent(customEvtName, {
+						detail: customEvtPayload
+					})
+				);
+			});
+
+			expect(mockCb).toBeCalledTimes(1);
+			expect(incomingPayload).toEqual(customEvtPayload);
+		});
+	});
+});

--- a/react-hooks/src/hooks/useSubscribeToCustomEvent/index.ts
+++ b/react-hooks/src/hooks/useSubscribeToCustomEvent/index.ts
@@ -2,7 +2,7 @@ import React from 'react';
 
 /**
  * useSubscribeToCustomEvent() - Custom react hook to subscribe and manage lifecycle of custom events.
- * @see - https://react-hooks.abhushan.dev/hooks/state/usesubscrivetocustomevent/
+ * @see - https://react-hooks.abhushan.dev/hooks/state/usesubscribetocustomevent/
  */
 export const useSubscribeToCustomEvent = <T>(eventName: string, callback: (e: CustomEvent<T>) => void) => {
 	/**

--- a/react-hooks/src/hooks/useSubscribeToCustomEvent/index.ts
+++ b/react-hooks/src/hooks/useSubscribeToCustomEvent/index.ts
@@ -1,0 +1,33 @@
+import React from 'react';
+
+/**
+ * useSubscribeToCustomEvent() - Custom react hook to subscribe and manage lifecycle of custom events.
+ * @see - https://react-hooks.abhushan.dev/hooks/state/usesubscrivetocustomevent/
+ */
+export const useSubscribeToCustomEvent = <T>(eventName: string, callback: (e: CustomEvent<T>) => void) => {
+	/**
+	 * This can be replaced with useEffect Event in future
+	 */
+	const callbackRef = React.useRef(callback);
+	React.useEffect(() => {
+		callbackRef.current = callback;
+	});
+
+	const evtCallback = React.useCallback((e: Event) => {
+		if (e instanceof CustomEvent) {
+			callbackRef.current(e as CustomEvent<T>);
+		}
+	}, []);
+
+	const unSubscribe = React.useCallback(() => {
+		window.removeEventListener(eventName, evtCallback);
+	}, [eventName, evtCallback]);
+
+	React.useEffect(() => {
+		window.addEventListener(eventName, evtCallback);
+
+		return unSubscribe;
+	}, [eventName, unSubscribe, evtCallback]);
+
+	return unSubscribe;
+};

--- a/react-hooks/src/index.ts
+++ b/react-hooks/src/index.ts
@@ -60,3 +60,4 @@ export { useLimitCallback } from './hooks/useLimitCallback';
 export { useDebounce } from './hooks/useDebounce';
 export { useThrottle } from './hooks/useThrottle';
 export { useDispatchCustomEvent } from './hooks/useDispatchCustomEvent';
+export { useSubscribeToCustomEvent } from './hooks/useSubscribeToCustomEvent';

--- a/www/src/components/demo/useSubscribeToCustomEvent/index.tsx
+++ b/www/src/components/demo/useSubscribeToCustomEvent/index.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { useDispatchCustomEvent, useSubscribeToCustomEvent } from '@abhushanaj/react-hooks';
+
+import Button from '@/components/docs/button';
+
+type CustomWindow = Window &
+	typeof globalThis & {
+		state: {
+			value: number;
+		};
+	};
+
+function ChildComponent() {
+	const [windowValue, setWindowValue] = React.useState(0);
+
+	const unSubscribe = useSubscribeToCustomEvent<{ newValue: number }>('valueChanged', (e) => {
+		setWindowValue(e.detail.newValue);
+	});
+
+	return (
+		<div>
+			<p>window.state.value is :{JSON.stringify(windowValue)}</p>
+			<Button variant="secondary" onClick={unSubscribe}>
+				Unsubscribe
+			</Button>
+		</div>
+	);
+}
+
+function UseSubscribeToCustomEventExample() {
+	const dispatch = useDispatchCustomEvent('valueChanged');
+
+	React.useEffect(() => {
+		(window as CustomWindow).state = { value: 10 };
+		dispatch({ newValue: 0 });
+
+		(window as CustomWindow).state = new Proxy((window as CustomWindow).state, {
+			set(obj, prop, value) {
+				if (prop === 'value') {
+					dispatch({ newValue: value });
+				}
+
+				// @ts-expect-error
+				obj[prop] = value;
+
+				return true;
+			}
+		});
+	}, []);
+
+	const updateWindowValue = (newValue: number) => {
+		(window as CustomWindow).state.value = newValue;
+	};
+
+	return (
+		<div className="flex flex-col gap-2">
+			<ChildComponent />
+			<Button variant="secondary" onClick={() => updateWindowValue(20)}>
+				Set window.state.value=20
+			</Button>
+			<Button variant="secondary" onClick={() => updateWindowValue(30)}>
+				Set window.state.value=30
+			</Button>
+
+			<small>Update the window.state.value from console and see it reflect above.</small>
+			<small>
+				The example above is simply creating a proxy over window.state and for every set action performed on it,
+				dispatching action which the component is subscribing to.
+			</small>
+		</div>
+	);
+}
+
+export default UseSubscribeToCustomEventExample;

--- a/www/src/content/docs/hooks/utilities/useDispatchCustomEvent.mdx
+++ b/www/src/content/docs/hooks/utilities/useDispatchCustomEvent.mdx
@@ -13,6 +13,8 @@ The `useDispatchCustomEvent` hook is helpful when you want to dispatch your own 
 
 This is helpful in scenarios like flushing pending actions after auth is completed, clearing pending analytics queue based om user action or sucessful load of analytics scripts.
 
+The hook can be used in conjunction with[useSubscribeToCustomEvent](/hooks/utilities/usesubscribetocustomevent/).
+
 <DemoWrapper title="useDispatchCustomEvent">
 	<Example client:load />
 </DemoWrapper>

--- a/www/src/content/docs/hooks/utilities/useSubscribeToCustomEvent.mdx
+++ b/www/src/content/docs/hooks/utilities/useSubscribeToCustomEvent.mdx
@@ -1,0 +1,69 @@
+---
+title: useSubscribeToCustomEvent
+description: 'Subscribe and manage lifecycle for a custom event.'
+subtitle: 'Subscribe and manage lifecycle for a custom event.'
+sidebar:
+  badge: 'New'
+---
+
+import Example from '@/components/demo/useSubscribeToCustomEvent';
+import { DemoWrapper } from '@/components/demo/wrapper';
+
+The `useSubscribeToCustomEvent` hook is helpful when you want to subscribe and manage the lifecycle of your own custom events with payloads.
+
+This is helpful in scenarios like flushing pending actions after auth is completed, clearing pending analytics queue based om user action or sucessful load of analytics scripts.
+
+The hook can be used in conjunction with[useDispatchCustomEvent](/hooks/utilities/usedispatchcustomevent/).
+
+<DemoWrapper title="useSubscribeToCustomEvent">
+	<Example client:load />
+</DemoWrapper>
+
+## Usage
+
+Import the hook from `@abhushanaj/react-hooks` and use in required component.
+
+```tsx title="./src/App.tsx" ins={2,10-13} mark="useSubscribeToCustomEvent"
+import React from 'react';
+import { useSubscribeToCustomEvent } from '@abhushanaj/react-hooks';
+
+function App() {
+	type Payload = {
+		type: 'RESET';
+		newQueue: Array<unknown>;
+	};
+
+	const unSubscribe = useSubscribeToCustomEvent<Payload>('queueChange', (e) => {
+		console.log('Dispatched payload at', e.detail);
+	});
+
+	return (
+		<div>
+			<button onClick={unSubscribe}>Unsubscribe</button>
+		</div>
+	);
+}
+
+export default App;
+```
+
+## Properties
+
+1. The `useSubscribeToCustomEvent` automatically unsubscribes from the event on component mount, so you do not need to worry about cleanups. However it does return a `unsubscribe` function back for cases where you want to take control of this. Once unsubscribe the event cannot be subscribed to again.
+
+2. You can use the generic `useSubscribeToCustomEvent<Payload>(eventName, callback)` when you know the payload type. However, I recommend validating the payload first instead of relying on this approach.
+
+## API Reference
+
+### Parameters
+
+| Parameter     | Type                        | Description                                             | Default |
+| ------------- | --------------------------- | ------------------------------------------------------- | ------- |
+| eventName     | `string`                    | The name of the custom event name you want to dispatch. | N/A     |
+| eventCallback | `(e: CustomEvent<T>=>void)` | The callback which gets invoked when event is fired.    | N/A     |
+
+### Return Value
+
+| Parameter   | Type       | Description                           | Default |
+| ----------- | ---------- | ------------------------------------- | ------- |
+| unsubscribe | `()=>void` | The unsubscribe method for the event. | N/A     |


### PR DESCRIPTION
# useSubscribeToCustomEvent

Custom react hook to subscribe and manage lifecycle of custom events.

Tasks done

- [x] Add hook 
- [x] Add test
- [x] Add docs
- [x] Add changelogs

Also updates the `useDispatchCustomAction` hook documentation to highlight the hook to be used in conjuction.